### PR TITLE
ci: upgrade: use last release as base (FROM)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,9 +63,9 @@ steps:
     depends_on:
       - "unit-tests"
     env:
-      # Fetch the latest Opstrace CLI artifact from S3 and use that as the
-      # initial cluster version.
-      OPSTRACE_CLI_VERSION_FROM: cli/main/latest/opstrace-cli-linux-amd64-latest.tar.bz2
+      # Fetch the latest Opstrace CLI release and use that as the initial
+      # cluster version.
+      OPSTRACE_CLI_VERSION_FROM: https://go.opstrace.com/cli-latest-release-linux
       # Use the Opstrace CLI artifact built from the PR branch to upgrade the
       # cluster.
       OPSTRACE_CLI_VERSION_TO: ${OPSTRACE_PREBUILD_DIR}/build/bin/opstrace


### PR DESCRIPTION
Also change `fetch_cli_s3_artifact` to a function
that downloads from any URL via curl, instead
of being S3-specific.

# Have you...

* [ ] Discussed your change with a project contributor in an issue yet?
* [ ] Added an explanation of what your changes do?
* [ ] Written new tests for your changes?
* [ ] Thought about which docs need updating?
